### PR TITLE
Add MANIFEST.in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__
 # Coverage
 .coverage
 htmlcov
+
+# Build
+dist/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements*.txt LICENSE README.md pyproject.toml setup.cfg


### PR DESCRIPTION
This ensures the package can be built.

The release of `oteapi-dlite` on PyPI for v0.0.1 will be based on this branch.