### PR TITLE
Add Excel file to cache in test

### DIFF
--- a/tests/strategies/test_parse_excel.py
+++ b/tests/strategies/test_parse_excel.py
@@ -11,11 +11,13 @@ def test_parse_excel(static_files: "Path") -> None:
     """Test excel parse strategy."""
     import dlite
     import numpy as np
+    from oteapi.datacache import DataCache
 
     from oteapi_dlite.strategies.parse_excel import DLiteExcelStrategy
 
     sample_file = static_files / "test_parse_excel.xlsx"
 
+    cache_key = DataCache().add(sample_file.read_bytes())
     config = {
         "downloadUrl": sample_file.as_uri(),
         "mediaType": "application/vnd.dlite-xlsx",
@@ -29,7 +31,10 @@ def test_parse_excel(static_files: "Path") -> None:
     }
 
     coll = dlite.Collection()
-    session = {"collection_id": coll.uuid}
+    session = {
+        "collection_id": coll.uuid,
+        "key": cache_key,
+    }
 
     parser = DLiteExcelStrategy(config)
     session.update(parser.initialize(session))


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Fixes #49 

Before using the Excel parser, the Excel file must have been downloaded and stored in the data cache.
This was previously not the case, but this fix implements that pre-storage.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [X] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand, including clearly named variables?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
