### PR TITLE
Removed resource-management issues by assuming OTEAPI drives everything

### DIFF
--- a/oteapi_dlite/strategies/parse.py
+++ b/oteapi_dlite/strategies/parse.py
@@ -120,8 +120,8 @@ class DLiteParseStrategy:
         else:
             if cacheconfig and cacheconfig.accessKey:
                 key = cacheconfig.accessKey
-            elif "key" in session:  # type: ignore
-                key = session["key"]  # type: ignore
+            elif session and "key" in session:
+                key = session["key"]
             else:
                 raise ValueError(
                     "either `location` or `cacheconfig.accessKey` must be "

--- a/oteapi_dlite/strategies/parse.py
+++ b/oteapi_dlite/strategies/parse.py
@@ -142,11 +142,15 @@ class DLiteParseStrategy:
         coll.add(config.label, inst)
 
         # __TODO__
-        # Can we savely assume that all strategies in a pipeline will be
-        # executed in the same Python interpreter?  If not, we should write
-        # the collection to a storage, such that it can be shared with the
-        # other strategies.
-
+        # See
+        # https://github.com/EMMC-ASBL/oteapi-dlite/pull/84#discussion_r1050437185
+        # and following comments.
+        #
+        # Since we cannot safely assume that all strategies in a
+        # pipeline will be executed in the same Python interpreter,
+        # the collection should be written to a storage, such that it
+        # can be shared with the other strategies.
+        #
         return DLiteSessionUpdate(collection_id=coll.uuid)
 
 

--- a/oteapi_dlite/utils/__init__.py
+++ b/oteapi_dlite/utils/__init__.py
@@ -3,6 +3,6 @@
 This module provide some utility functions.
 """
 from .nputils import dict2recarray
-from .utils import get_driver, get_meta, init_session
+from .utils import get_collection, get_driver, get_meta
 
-__all__ = ("dict2recarray", "get_driver", "get_meta", "init_session")
+__all__ = ("dict2recarray", "get_driver", "get_meta", "get_collection")

--- a/oteapi_dlite/utils/utils.py
+++ b/oteapi_dlite/utils/utils.py
@@ -41,9 +41,9 @@ def get_collection(session):
     if "collection_id" not in session:
         coll = dlite.Collection()
         session["collection_id"] = coll.uuid
+        return coll
 
-    coll = dlite.get_instance(session["collection_id"])
-    return coll
+    return dlite.get_instance(session["collection_id"])
 
 
 def get_meta(uri: str) -> dlite.Instance:

--- a/oteapi_dlite/utils/utils.py
+++ b/oteapi_dlite/utils/utils.py
@@ -1,6 +1,5 @@
 """Utility functions for OTEAPI DLite plugin."""
 # pylint: disable=invalid-name
-import weakref
 from pathlib import Path
 
 import dlite
@@ -33,8 +32,9 @@ ACCESSSERVICES = {
 }
 
 
-def init_session(session):
-    """Initialise session if it is not already initialised."""
+def get_collection(session):
+    """Makes sure that the session contain a `collection_id` and returns
+    the collection."""
     if session is None:
         raise ValueError("Missing session")
 
@@ -42,13 +42,8 @@ def init_session(session):
         coll = dlite.Collection()
         session["collection_id"] = coll.uuid
 
-        # Make sure that collection stays alive when leaving this function
-        coll._incref()  # pylint: disable=protected-access
-
-        # Call _decref() on the collection when `session` is garbage collected
-        weakref.finalize(
-            session, coll._decref  # pylint: disable=protected-access
-        )
+    coll = dlite.get_instance(session["collection_id"])
+    return coll
 
 
 def get_meta(uri: str) -> dlite.Instance:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,5 @@
 [options.entry_points]
 oteapi.parse =
-  oteapi_dlite.image/vnd.dlite-gif = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
-  oteapi_dlite.image/vnd.dlite-jpeg = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
-  oteapi_dlite.image/vnd.dlite-jpg = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
-  oteapi_dlite.image/vnd.dlite-jp2 = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
-  oteapi_dlite.image/vnd.dlite-png = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
-  oteapi_dlite.image/vnd.dlite-tiff = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
-  oteapi_dlite.application/vnd.dlite-xlsx = oteapi_dlite.strategies.parse_excel:DLiteExcelStrategy
   oteapi_dlite.application/vnd.dlite-parse = oteapi_dlite.strageties.parse:DLiteParseStrategy
   #oteapi_dlite.application/json = oteapi_dlite.strageties.parse:DLiteParseStrategy
   #oteapi_dlite.application/yaml = oteapi_dlite.strategies.parse:DLiteParseStrategy
@@ -17,10 +10,22 @@ oteapi.parse =
   #oteapi_dlite.application/n-triples = oteapi_dlite.strategies.parse:DLiteParseStrategy
   #oteapi_dlite.text/turtle = oteapi_dlite.strategies.parse:DLiteParseStrategy
   #oteapi_dlite.text/csv = oteapi_dlite.strategies.parse:DLiteParseStrategy
+  #oteapi_dlite.image/gif = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
+  #oteapi_dlite.image/jpeg = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
+  #oteapi_dlite.image/jpg = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
+  #oteapi_dlite.image/png = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
+  #oteapi_dlite.image/tiff = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
 
   # To be removed
   oteapi_dlite.application/vnd.dlite-json = oteapi_dlite.strategies.parse:DLiteParseStrategy
   oteapi_dlite.application/vnd.dlite-yaml = oteapi_dlite.strategies.parse:DLiteParseStrategy
+  oteapi_dlite.application/vnd.dlite-xlsx = oteapi_dlite.strategies.parse_excel:DLiteExcelStrategy
+  oteapi_dlite.image/vnd.dlite-gif = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
+  oteapi_dlite.image/vnd.dlite-jpeg = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
+  oteapi_dlite.image/vnd.dlite-jpg = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
+  oteapi_dlite.image/vnd.dlite-jp2 = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
+  oteapi_dlite.image/vnd.dlite-png = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
+  oteapi_dlite.image/vnd.dlite-tiff = oteapi_dlite.strategies.parse_image:DLiteImageParseStrategy
 
 
 oteapi.function =


### PR DESCRIPTION
Updated oteapi-dlite so that it does not assume that the user application runs OTEAPI, but rather that OTEAPI runs the application.

This PR remove the needs for the following PRs:
* https://github.com/EMMC-ASBL/oteapi-core/pull/207
* https://github.com/EMMC-ASBL/otelib/pull/83
* https://github.com/EMMC-ASBL/otelib/pull/84


# Description:
<!-- Summary of change, including the issue to be addressed. -->

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand, including clearly named variables?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?

---

Closes EMMC-ASBL/oteapi-core#207
Closes EMMC-ASBL/otelib#83
Closes EMMC-ASBL/otelib#84