### PR TITLE
Add tuple as input type in `parse_excel.infer_metadata()`

### DIFF
--- a/oteapi_dlite/strategies/parse_excel.py
+++ b/oteapi_dlite/strategies/parse_excel.py
@@ -2,7 +2,7 @@
 # pylint: disable=unused-argument
 import re
 from random import getrandbits
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 import dlite
 import numpy as np
@@ -153,7 +153,10 @@ def split_column_name(column):
     return name, unit
 
 
-def infer_metadata(rec: np.recarray, units: list) -> dlite.Instance:
+def infer_metadata(
+    rec: np.recarray,
+    units: Union[list, tuple]
+) -> dlite.Instance:
     """Infer dlite metadata from recarray `rec`."""
     rnd = getrandbits(128)
     uri = f"http://onto-ns.com/meta/1.0/generated_from_excel_{rnd:0x}"

--- a/oteapi_dlite/strategies/parse_excel.py
+++ b/oteapi_dlite/strategies/parse_excel.py
@@ -2,7 +2,7 @@
 # pylint: disable=unused-argument
 import re
 from random import getrandbits
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional
 
 import dlite
 import numpy as np
@@ -153,9 +153,7 @@ def split_column_name(column):
     return name, unit
 
 
-def infer_metadata(
-    rec: np.recarray, units: Union[list, tuple]
-) -> dlite.Instance:
+def infer_metadata(rec: np.recarray, units: tuple) -> dlite.Instance:
     """Infer dlite metadata from recarray `rec`."""
     rnd = getrandbits(128)
     uri = f"http://onto-ns.com/meta/1.0/generated_from_excel_{rnd:0x}"

--- a/oteapi_dlite/strategies/parse_excel.py
+++ b/oteapi_dlite/strategies/parse_excel.py
@@ -2,7 +2,7 @@
 # pylint: disable=unused-argument
 import re
 from random import getrandbits
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Sequence
 
 import dlite
 import numpy as np
@@ -153,7 +153,7 @@ def split_column_name(column):
     return name, unit
 
 
-def infer_metadata(rec: np.recarray, units: tuple[str, ...]) -> dlite.Instance:
+def infer_metadata(rec: np.recarray, units: Sequence[str, ...]) -> dlite.Instance:
     """Infer dlite metadata from recarray `rec`."""
     rnd = getrandbits(128)
     uri = f"http://onto-ns.com/meta/1.0/generated_from_excel_{rnd:0x}"

--- a/oteapi_dlite/strategies/parse_excel.py
+++ b/oteapi_dlite/strategies/parse_excel.py
@@ -2,7 +2,7 @@
 # pylint: disable=unused-argument
 import re
 from random import getrandbits
-from typing import TYPE_CHECKING, Optional, Sequence
+from typing import TYPE_CHECKING, Optional
 
 import dlite
 import numpy as np
@@ -153,7 +153,7 @@ def split_column_name(column):
     return name, unit
 
 
-def infer_metadata(rec: np.recarray, units: Sequence[str, ...]) -> dlite.Instance:
+def infer_metadata(rec: np.recarray, units: tuple[str, ...]) -> dlite.Instance:
     """Infer dlite metadata from recarray `rec`."""
     rnd = getrandbits(128)
     uri = f"http://onto-ns.com/meta/1.0/generated_from_excel_{rnd:0x}"

--- a/oteapi_dlite/strategies/parse_excel.py
+++ b/oteapi_dlite/strategies/parse_excel.py
@@ -154,8 +154,7 @@ def split_column_name(column):
 
 
 def infer_metadata(
-    rec: np.recarray,
-    units: Union[list, tuple]
+    rec: np.recarray, units: Union[list, tuple]
 ) -> dlite.Instance:
     """Infer dlite metadata from recarray `rec`."""
     rnd = getrandbits(128)

--- a/oteapi_dlite/strategies/parse_excel.py
+++ b/oteapi_dlite/strategies/parse_excel.py
@@ -153,7 +153,7 @@ def split_column_name(column):
     return name, unit
 
 
-def infer_metadata(rec: np.recarray, units: tuple) -> dlite.Instance:
+def infer_metadata(rec: np.recarray, units: tuple[str, ...]) -> dlite.Instance:
     """Infer dlite metadata from recarray `rec`."""
     rnd = getrandbits(128)
     uri = f"http://onto-ns.com/meta/1.0/generated_from_excel_{rnd:0x}"


### PR DESCRIPTION
# Description:
`parse_excel.infer_metadata()` expects its input parameter `units` as a `list`, but we want to send a `tuple` from `get()`. Suggested solution is to add handling of `tuple`.

Closes #212.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand, including clearly named variables?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
