### PR TITLE
Improved control over partial pipeline created with the generate strategy

### DIFF
--- a/oteapi_dlite/strategies/mapping.py
+++ b/oteapi_dlite/strategies/mapping.py
@@ -6,10 +6,13 @@ from typing import TYPE_CHECKING, Annotated, Optional
 from oteapi.models import AttrDict, MappingConfig
 from pydantic import AnyUrl
 from pydantic.dataclasses import Field, dataclass
-from tripper import Triplestore
 
 from oteapi_dlite.models import DLiteSessionUpdate
-from oteapi_dlite.utils import get_collection, update_collection
+from oteapi_dlite.utils import (
+    get_collection,
+    get_triplestore,
+    update_collection,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any
@@ -53,8 +56,10 @@ class DLiteMappingStrategy:
         self, session: Optional[dict[str, "Any"]] = None
     ) -> DLiteSessionUpdate:
         """Initialize strategy."""
-        coll = get_collection(session)
-        ts = Triplestore(backend="collection", collection=coll)
+        if session is None:
+            session = {}
+
+        ts = get_triplestore(session)
 
         if self.mapping_config.prefixes:
             for prefix, iri in self.mapping_config.prefixes.items():
@@ -71,6 +76,7 @@ class DLiteMappingStrategy:
                 ]
             )
 
+        coll = get_collection(session)
         update_collection(coll)
         return DLiteSessionUpdate(collection_id=coll.uuid)
 

--- a/oteapi_dlite/utils/__init__.py
+++ b/oteapi_dlite/utils/__init__.py
@@ -5,22 +5,30 @@ This module provide some utility functions.
 
 from .nputils import dict2recarray
 from .utils import (
+    RemoveItem,
+    TypeMismatchError,
     add_settings,
     get_collection,
     get_driver,
     get_instance,
     get_meta,
     get_settings,
+    get_triplestore,
     update_collection,
+    update_dict,
 )
 
 __all__ = (
+    "RemoveItem",
+    "TypeMismatchError",
+    "add_settings",
     "dict2recarray",
+    "get_collection",
     "get_driver",
     "get_meta",
     "get_instance",
-    "get_collection",
-    "update_collection",
-    "add_settings",
     "get_settings",
+    "get_triplestore",
+    "update_collection",
+    "update_dict",
 )

--- a/oteapi_dlite/utils/utils.py
+++ b/oteapi_dlite/utils/utils.py
@@ -146,7 +146,7 @@ def get_driver(
     raise ValueError("either `mediaType` or `accessService` must be provided")
 
 
-def get_instance(  # pylint: disable=too-many-arguments
+def get_instance(
     meta: "Union[str, dlite.Metadata]",
     session: "Optional[dict[str, Any]]" = None,
     collection: "Optional[dlite.Collection]" = None,
@@ -174,6 +174,7 @@ def get_instance(  # pylint: disable=too-many-arguments
     """
     # Import here to avoid a hard dependency on tripper.
     # pylint: disable=import-outside-toplevel
+    # pylint: disable=too-many-positional-arguments,too-many-arguments
     from tripper import Triplestore
 
     if collection is None:

--- a/oteapi_dlite/utils/utils.py
+++ b/oteapi_dlite/utils/utils.py
@@ -155,6 +155,7 @@ def get_instance(
     allow_incomplete: bool = False,
     **kwargs,
 ) -> dlite.Instance:
+    # pylint: disable=import-outside-toplevel,too-many-arguments
     """Instantiates and returns an instance of `meta`.
 
     Arguments:
@@ -173,7 +174,6 @@ def get_instance(
         kwargs: Additional arguments passed to dlite.mappings.instantiate().
     """
     # Import here to avoid a hard dependency on tripper.
-    # pylint: disable=import-outside-toplevel,too-many-arguments
     from tripper import Triplestore
 
     if collection is None:

--- a/oteapi_dlite/utils/utils.py
+++ b/oteapi_dlite/utils/utils.py
@@ -146,7 +146,7 @@ def get_driver(
     raise ValueError("either `mediaType` or `accessService` must be provided")
 
 
-def get_instance(
+def get_instance(  # pylint: disable=too-many-arguments
     meta: "Union[str, dlite.Metadata]",
     session: "Optional[dict[str, Any]]" = None,
     collection: "Optional[dlite.Collection]" = None,
@@ -155,7 +155,6 @@ def get_instance(
     allow_incomplete: bool = False,
     **kwargs,
 ) -> dlite.Instance:
-    # pylint: disable=import-outside-toplevel,too-many-arguments
     """Instantiates and returns an instance of `meta`.
 
     Arguments:
@@ -174,6 +173,7 @@ def get_instance(
         kwargs: Additional arguments passed to dlite.mappings.instantiate().
     """
     # Import here to avoid a hard dependency on tripper.
+    # pylint: disable=import-outside-toplevel
     from tripper import Triplestore
 
     if collection is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,23 +36,23 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = [
-    "mike~=2.1",
-    "mkdocs>=1.5.3,<1.7",
-    "mkdocs-awesome-pages-plugin~=2.9",
-    "mkdocs-material>=9.5.5,<10",
-    "mkdocstrings[python]~=0.25.1",
+    "mike==2.1.3",
+    "mkdocs==1.6.1",
+    "mkdocs-awesome-pages-plugin==2.9.3",
+    "mkdocs-material==9.5.34",
+    "mkdocstrings[python]==0.25.2",
 ]
 testing = [
     "PyYAML>=5.4.1,<7",
     "otelib>=0.4.0,<1",
-    "pytest~=7.4",
-    "pytest-cov~=4.1",
     "rdflib>=5.0.0,<8",
-    "pylint>=3.0.0,<4",
+    "pytest==7.4.4",
+    "pytest-cov==4.1.0",
+    "pylint==3.3.1",
 ]
 dev = [
-    "pre-commit~=3.7",
     "oteapi-dlite[docs,testing]",
+    "pre-commit==3.8.0",
 ]
 
 [project.urls]

--- a/tests/strategies/test_generate_kb.py
+++ b/tests/strategies/test_generate_kb.py
@@ -86,6 +86,7 @@ def test_generate_kb():
             "location": str(outdir / "image.json"),
             "options": "mode=w",
             "kb_document_class": ":MyData",
+            "kb_document_update": {"dataresource": {"license": "MIT"}},
             "kb_document_base_iri": "http://ex.com#",
             "kb_document_context": {EMMO.isDescriptionFor: ":MyMaterial"},
             "kb_document_computation": ":Sim",
@@ -141,11 +142,18 @@ def test_generate_kb():
             "type": ":MyData",
             "downloadUrl": str((outdir / "image.json")),
             "mediaType": "application/vnd.dlite-parse",
+            "license": "MIT",
             "configuration": {
                 "driver": "json",
-                "options": "mode=w",
-                "metadata": "http://onto-ns.com/meta/1.0/Image",
+                "options": "mode=r",
+                "datamodel": "http://onto-ns.com/meta/1.0/Image",
             },
+        },
+        # "parse": {}
+        "mapping": {
+            "mappingType": "mappings",
+            # "prefixes": {},
+            # "triples": [],
         },
     }
 

--- a/tests/strategies/test_mapping.py
+++ b/tests/strategies/test_mapping.py
@@ -22,9 +22,13 @@ def test_mapping_without_prefixes() -> None:
         ],
     )
 
-    mapper = DLiteMappingStrategy(config)
-    session = mapper.initialize()
-    session.update(mapper.get(session))
+    session = {}
+
+    strategy = DLiteMappingStrategy(config)
+    session.update(strategy.initialize(session))
+
+    strategy = DLiteMappingStrategy(config)
+    session.update(strategy.get(session))
 
     collection = get_collection(session)
     relations = set(collection.get_relations())

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -19,3 +19,34 @@ def test_settings():
     assert get_settings(session, "settings2") == settings2
     assert get_settings(session, "settings3") == settings3
     assert get_settings(session, "non-existing-settings") is None
+
+
+# if True:
+def test_update_dict():
+    """Test update_dict()."""
+    import pytest
+
+    from oteapi_dlite.utils import TypeMismatchError, update_dict
+
+    dct = {
+        "a": 1,
+        "b": {
+            "c": [1, 2, 3],
+            "d": None,
+            "e": {"f": "string_value"},
+        },
+    }
+
+    d1 = update_dict(dct.copy(), {"a": 2.2})
+    assert d1["a"] == 2.2  # Accept conversion between numbers types
+    assert d1["b"] == dct["b"]
+
+    d2 = update_dict(dct.copy(), {"b": {"c": [5]}})
+    assert d2["a"] == dct["a"]
+    assert d2["b"]["c"] == [5]
+    assert d2["b"]["d"] == dct["b"]["d"]
+    assert d2["b"]["e"] == dct["b"]["e"]
+
+    # Do not accept conversion between other types
+    with pytest.raises(TypeMismatchError):
+        update_dict(dct.copy(), {"a": "abc..."})


### PR DESCRIPTION
# Description:
Added `kb_document_update` configuration to the `generate` strategy to improve the control over the created partial pipeline documenting the stored instance. 

Other improvements:
- Added `utils.get_triplestore()` for a consistent way to get the triplestore.
- Updated the mapping strategy to use `utils.get_triplestore()`.
- Updated `utils.get_instance()` to use `utils.get_triplestore()`. 

Included bugfixes: 
- Renamed dlite-parse strategy configuration `matadata` to `datamodel`.
- In `utils.get_collection()`, do not create a new session object if session is an empty dict.

To be done:
- Get default mapping from current pipeline. This can be done by querying the triplestore. Better to do this after we have update save_container()/load_container() in `tripper.convert` serialise oteapi configurations in an easier parsable way.

## Type of change:
- [x] Bug fix.
- [x] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand, including clearly named variables?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
