### PR TITLE
Tripper>=0.3.5 resolves EMMO namespace correctly.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "pydantic-settings>=2.0,<3",
     "typing-extensions>=4.8,<5; python_version<'3.10'",
     "Pillow>=9.0.1,<12",
-    "tripper>=0.3.4, <0.3.5",
+    #"tripper>=0.3.4, <0.3.5",
+    "tripper[mappings] @ git+https://github.com/EMMC-ASBL/tripper@master",
 ]
 
 [project.optional-dependencies]

--- a/tests/strategies/test_mapping.py
+++ b/tests/strategies/test_mapping.py
@@ -64,11 +64,19 @@ def test_mapping_with_prefixes() -> None:
             "emmo": str(EMMO),
         },
         triples=[
-            ("f:forces", "map:mapsTo", "emmo:Force"),
-            ("e:energy", "map:mapsTo", "emmo:PotentialEnergy"),
+            # From tripper 0.3.5 importing EMMO as namespace resolves correctly
+            (
+                "f:forces",
+                "map:mapsTo",
+                "https://w3id.org/emmo#EMMO_1f087811_06cb_42d5_90fb_25d0e7e068ef",
+            ),
+            (
+                "e:energy",
+                "map:mapsTo",
+                "https://w3id.org/emmo#EMMO_4c151909_6f26_4ef9_b43d_7c9e9514883a",
+            ),
         ],
     )
-
     session = DLiteMappingStrategy(config).initialize()
 
     # Remove the line immediately below once EMMC-ASBL/oteapi#545 is fixed


### PR DESCRIPTION
# Description:
From tripper 0.3.5 importing EMMO as namespace resolves correctly. 

I.e. EMMO.Force resolves to 
https://w3id.org/emmo#EMMO_1f087811_06cb_42d5_90fb_25d0e7e068ef

It makes not longer sense to use "emmo:Force"  in the mapping as the prefix will be resolved, but not the full IRI.



<!-- Summary of change, including the issue to be addressed. -->

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand, including clearly named variables?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
